### PR TITLE
feat: single server forward with concurrency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 reqwest = "0.12.12"
-tokio = "1.43.0"
+tokio = {version = "1.43.0", features = ["full"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-reqwest = "0.12.12"
+http = "1.2.0"
 tokio = {version = "1.43.0", features = ["full"]}
+hyper = { version = "1", features = ["full"] }
+http-body-util = "0.1"
+hyper-util = { version = "0.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+reqwest = "0.12.12"
+tokio = "1.43.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,30 +4,32 @@ use std::{
     str::FromStr,
 };
 
-use reqwest::{Method, Request, Url};
+use reqwest::{Client, Method, Request, Url};
+use tokio;
 
 #[derive(Debug)]
 struct Message {
     method: Method,
     path: String,
     host: IpAddr,
-    port: String,
+    port: u32,
 }
 
-fn produce_message_from_stream(stream: TcpStream) -> Message {
+// TODO: In the future it is a good idea to to a from implementation
+// but we dont even know if this is the correct choice yet so lets leave
+// for now.
+async fn produce_message_from_stream(stream: TcpStream) -> Message {
     let mut buf_reader = BufReader::new(&stream).lines();
     let request_line = buf_reader.next().unwrap().unwrap();
-    let host_line = buf_reader.next().unwrap().unwrap();
 
     let request: Vec<&str> = request_line.split(" ").collect();
-    let host_and_port: Vec<&str> = host_line.split(" ").collect();
-    let addr = host_and_port[1];
-    let addr_parts: Vec<&str> = addr.split(":").collect();
 
     let method = Method::from_str(request[0]).expect("could not parse string to method");
     let path = request[1].to_string();
-    let host = IpAddr::from_str(addr_parts[0]).expect("could not parse IpAddr");
-    let port = addr_parts[1].to_string();
+
+    // for now there is no dyanmic back ends for the LB so just hard code to validate
+    let host = IpAddr::from_str("127.0.0.1").expect("wrong host");
+    let port = 5002;
 
     Message {
         method,
@@ -37,16 +39,44 @@ fn produce_message_from_stream(stream: TcpStream) -> Message {
     }
 }
 
-fn main() {
+async fn process_stream(stream: TcpStream) {
+    let message = produce_message_from_stream(stream).await;
+
+    // Some basic logging for now, implement tracing when we know this is the solution wanted
+    println!("{:?}", message);
+
+    // This should all be wrapped up to produce a request from a message
+    let url = Url::parse(&format!(
+        "http://{}:{}{}",
+        &message.host, &message.port, &message.path
+    ))
+    .expect("could not parse URL");
+
+    println!("{:#?}", url);
+    let request = Request::new(message.method, url);
+
+    let client = Client::new();
+
+    let response = client
+        .execute(request)
+        .await
+        .expect("failed to execute request");
+
+    let response_text = response.text().await.expect("failed to get response text");
+
+    println!("{:?}", response_text);
+}
+
+#[tokio::main]
+async fn main() {
     println!("Starting LB");
 
     let listener = TcpListener::bind("127.0.0.1:5001").unwrap();
 
-    for stream in listener.incoming() {
-        let stream = stream.unwrap();
-
-        let message = produce_message_from_stream(stream);
-
-        println!("{:?}", message);
+    loop {
+        let (stream, _) = listener.accept().unwrap();
+        tokio::spawn(async move {
+            process_stream(stream).await;
+        });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,20 @@
-use std::{
-    io::{prelude::*, BufReader},
-    net::{IpAddr, TcpListener, TcpStream},
-    str::FromStr,
+use std::{net::IpAddr, str::FromStr};
+
+use hyper::{
+    body::{Buf, Bytes},
+    {Method, Request, Response, StatusCode, Uri},
+};
+use hyper_util::rt::TokioIo;
+
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    net::{TcpListener, TcpStream},
 };
 
-use reqwest::{Client, Method, Request, Url};
-use tokio;
+use http_body_util::{BodyExt, Empty, Full};
 
 #[derive(Debug)]
-struct Message {
+struct ForwardMessage {
     method: Method,
     path: String,
     host: IpAddr,
@@ -18,20 +24,21 @@ struct Message {
 // TODO: In the future it is a good idea to to a from implementation
 // but we dont even know if this is the correct choice yet so lets leave
 // for now.
-async fn produce_message_from_stream(stream: TcpStream) -> Message {
-    let mut buf_reader = BufReader::new(&stream).lines();
-    let request_line = buf_reader.next().unwrap().unwrap();
+async fn produce_message_from_stream(stream: &mut TcpStream) -> ForwardMessage {
+    let mut buf_reader = BufReader::new(stream).lines();
+    let request_line = buf_reader.next_line().await.unwrap().unwrap();
 
     let request: Vec<&str> = request_line.split(" ").collect();
 
-    let method = Method::from_str(request[0]).expect("could not parse string to method");
+    let method = Method::from_str(request[0]).expect("could not parse string to method"); // TODO:
+                                                                                          // handle error
     let path = request[1].to_string();
 
     // for now there is no dyanmic back ends for the LB so just hard code to validate
-    let host = IpAddr::from_str("127.0.0.1").expect("wrong host");
+    let host = IpAddr::from_str("127.0.0.1").expect("wrong host"); // TODO: handle error
     let port = 5002;
 
-    Message {
+    ForwardMessage {
         method,
         path,
         host,
@@ -39,42 +46,103 @@ async fn produce_message_from_stream(stream: TcpStream) -> Message {
     }
 }
 
-async fn process_stream(stream: TcpStream) {
-    let message = produce_message_from_stream(stream).await;
+async fn build_uri_from_message(message: ForwardMessage) -> Uri {
+    let url = Uri::builder()
+        .scheme("http")
+        .authority(format!(
+            "{}:{}",
+            message.host.to_string(),
+            message.port.to_string()
+        ))
+        .path_and_query(message.path)
+        .build()
+        .unwrap(); // TODO: handle error
 
-    // Some basic logging for now, implement tracing when we know this is the solution wanted
+    url
+}
+
+async fn call_downstream_server(
+    uri: Uri,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    let host = uri.host().expect("uri has no host");
+    let port = uri.port_u16().unwrap_or(5002);
+
+    let address = format!("{}:{}", host, port);
+
+    let stream = TcpStream::connect(address).await?;
+
+    let io = TokioIo::new(stream);
+
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
+
+    tokio::task::spawn(async move {
+        if let Err(err) = conn.await {
+            println!("Connection failed: {:?}", err);
+        }
+    });
+
+    let authority = uri.authority().unwrap().clone();
+
+    let req = Request::builder()
+        .uri(uri)
+        .header(hyper::header::HOST, authority.as_str())
+        .body(Empty::<Bytes>::new())?;
+
+    let mut res = sender.send_request(req).await?;
+
+    let mut response_bytes: Vec<u8> = Vec::new();
+
+    while let Some(next) = res.frame().await {
+        let frame = next?;
+        if let Some(chunk) = frame.data_ref() {
+            chunk.chunk().iter().for_each(|item| {
+                response_bytes.push(*item);
+            });
+        }
+    }
+
+    Ok(response_bytes)
+}
+
+async fn respond_to_client(bytes: Vec<u8>, mut stream: TcpStream) {
+    let response = Response::builder()
+        .version(hyper::Version::HTTP_11)
+        .status(StatusCode::OK)
+        .header("Content-Type", "text/plain")
+        .header("Content-Length", bytes.len())
+        .body(Full::new(Bytes::from(bytes.clone())))
+        .unwrap();
+
+    let headers = format!(
+        "HTTP/1.1 {}\r\n{:?}\r\n\r\n",
+        response.status(),
+        response.headers()
+    );
+
+    stream.write_all(headers.as_bytes()).await.unwrap();
+    stream
+        .write_all(&response.collect().await.unwrap().to_bytes())
+        .await
+        .unwrap();
+}
+
+async fn process_stream(mut stream: TcpStream) {
+    let message = produce_message_from_stream(&mut stream).await;
+
     println!("{:?}", message);
 
-    // This should all be wrapped up to produce a request from a message
-    let url = Url::parse(&format!(
-        "http://{}:{}{}",
-        &message.host, &message.port, &message.path
-    ))
-    .expect("could not parse URL");
+    let uri = build_uri_from_message(message).await;
 
-    println!("{:#?}", url);
-    let request = Request::new(message.method, url);
+    let downstream_response_bytes = call_downstream_server(uri).await.unwrap();
 
-    let client = Client::new();
-
-    let response = client
-        .execute(request)
-        .await
-        .expect("failed to execute request");
-
-    let response_text = response.text().await.expect("failed to get response text");
-
-    println!("{:?}", response_text);
+    respond_to_client(downstream_response_bytes, stream).await;
 }
 
 #[tokio::main]
 async fn main() {
-    println!("Starting LB");
-
-    let listener = TcpListener::bind("127.0.0.1:5001").unwrap();
-
+    let listener = TcpListener::bind("127.0.0.1:5001").await.unwrap();
     loop {
-        let (stream, _) = listener.accept().unwrap();
+        let (stream, _) = listener.accept().await.unwrap();
         tokio::spawn(async move {
             process_stream(stream).await;
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,27 @@
+use std::{
+    io::{prelude::*, BufReader},
+    net::{TcpListener, TcpStream},
+};
+
+fn handle_connection(stream: TcpStream) {
+    let buf_reader = BufReader::new(&stream);
+    let http_request: Vec<_> = buf_reader
+        .lines()
+        .map(|result| result.unwrap())
+        .take_while(|line| !line.is_empty())
+        .collect();
+
+    println!("Request: {http_request:#?}");
+}
+
 fn main() {
-    println!("Hello, world!");
+    println!("Starting LB");
+
+    let listener = TcpListener::bind("127.0.0.1:5001").unwrap();
+
+    for stream in listener.incoming() {
+        let stream = stream.unwrap();
+
+        handle_connection(stream);
+    }
 }


### PR DESCRIPTION
This PR aims to add a single server forward accepting connections concurrently. This is a naieve implementation with no error handeling, logging or dynamic backends just to prove out a single server forward with response across multiple threads. 