### PR TITLE
feat: implement round robin load balancing algorithm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,201 @@
+use std::{fmt::Display, net::IpAddr, ops::Index, str::FromStr};
+
+use hyper::{
+    body::{Buf, Bytes},
+    {Method, Request, Response, StatusCode, Uri},
+};
+use hyper_util::rt::TokioIo;
+
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    net::{TcpListener, TcpStream},
+};
+
+use http_body_util::{BodyExt, Empty, Full};
+
+#[derive(Debug)]
+struct ForwardMessage {
+    method: Method,
+    path: String,
+    host: IpAddr,
+    port: u32,
+}
+
+// TODO: In the future it is a good idea to to a from implementation
+// but we dont even know if this is the correct choice yet so lets leave
+// for now.
+async fn produce_message_from_stream(stream: &mut TcpStream) -> ForwardMessage {
+    let mut buf_reader = BufReader::new(stream).lines();
+    let request_line = buf_reader.next_line().await.unwrap().unwrap();
+
+    let request: Vec<&str> = request_line.split(" ").collect();
+
+    let method = Method::from_str(request[0]).expect("could not parse string to method"); // TODO:
+                                                                                          // handle error
+    let path = request[1].to_string();
+
+    // for now there is no dyanmic back ends for the LB so just hard code to validate
+    let host = IpAddr::from_str("127.0.0.1").expect("wrong host"); // TODO: handle error
+    let port = 5002;
+
+    ForwardMessage {
+        method,
+        path,
+        host,
+        port,
+    }
+}
+
+async fn build_uri_from_message(message: ForwardMessage) -> Uri {
+    let url = Uri::builder()
+        .scheme("http")
+        .authority(format!(
+            "{}:{}",
+            message.host.to_string(),
+            message.port.to_string()
+        ))
+        .path_and_query(message.path)
+        .build()
+        .unwrap(); // TODO: handle error
+
+    url
+}
+
+async fn call_downstream_server(
+    uri: Uri,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    let host = uri.host().expect("uri has no host");
+    let port = uri.port_u16().unwrap_or(5002);
+
+    let address = format!("{}:{}", host, port);
+
+    let stream = TcpStream::connect(address).await?;
+
+    let io = TokioIo::new(stream);
+
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
+
+    tokio::task::spawn(async move {
+        if let Err(err) = conn.await {
+            println!("Connection failed: {:?}", err);
+        }
+    });
+
+    let authority = uri.authority().unwrap().clone();
+
+    let req = Request::builder()
+        .uri(uri)
+        .header(hyper::header::HOST, authority.as_str())
+        .body(Empty::<Bytes>::new())?;
+
+    let mut res = sender.send_request(req).await?;
+
+    let mut response_bytes: Vec<u8> = Vec::new();
+
+    while let Some(next) = res.frame().await {
+        let frame = next?;
+        if let Some(chunk) = frame.data_ref() {
+            chunk.chunk().iter().for_each(|item| {
+                response_bytes.push(*item);
+            });
+        }
+    }
+
+    Ok(response_bytes)
+}
+
+async fn respond_to_client(bytes: Vec<u8>, mut stream: TcpStream) {
+    let response = Response::builder()
+        .version(hyper::Version::HTTP_11)
+        .status(StatusCode::OK)
+        .header("Content-Type", "text/plain")
+        .header("Content-Length", bytes.len())
+        .body(Full::new(Bytes::from(bytes.clone())))
+        .unwrap();
+
+    let headers = format!(
+        "HTTP/1.1 {}\r\n{:?}\r\n\r\n",
+        response.status(),
+        response.headers()
+    );
+
+    stream.write_all(headers.as_bytes()).await.unwrap();
+    stream
+        .write_all(&response.collect().await.unwrap().to_bytes())
+        .await
+        .unwrap();
+}
+
+pub async fn process_stream(mut stream: TcpStream, downstream_server: String) {
+    let message = produce_message_from_stream(&mut stream).await;
+
+    println!("{:?}", message);
+
+    let uri = build_uri_from_message(message).await;
+
+    let downstream_response_bytes = call_downstream_server(uri).await.unwrap();
+
+    respond_to_client(downstream_response_bytes, stream).await;
+}
+
+pub struct Server {
+    listener: TcpListener,
+    backends: Vec<Backend>,
+    count: usize,
+}
+
+impl Server {
+    pub async fn new(listener: TcpListener, backends: Vec<Backend>) -> Self {
+        Self {
+            listener,
+            backends,
+            count: 0,
+        }
+    }
+
+    pub async fn serve(&mut self) {
+        loop {
+            let (stream, _) = self.listener.accept().await.unwrap();
+
+            let backend = self.next_server_address();
+            println!("{}", backend);
+            println!("{}", self.count);
+
+            tokio::spawn(async move {
+                process_stream(stream, backend).await;
+            });
+        }
+    }
+
+    fn next_server_address(&mut self) -> String {
+        if self.count == self.backends.len() {
+            self.reset_count();
+        };
+
+        let backend = self.backends.get(self.count).unwrap().to_string();
+        self.count += 1;
+
+        backend
+    }
+
+    fn reset_count(&mut self) {
+        self.count = 0;
+    }
+}
+
+pub struct Backend {
+    ipaddr: IpAddr,
+    port: u32,
+}
+
+impl Backend {
+    pub fn new(ipaddr: IpAddr, port: u32) -> Self {
+        Self { ipaddr, port }
+    }
+}
+
+impl Display for Backend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.ipaddr, self.port)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,31 @@
 use std::net::IpAddr;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use prism_lb::Backend;
 use prism_lb::Server;
 
 use tokio::net::TcpListener;
+use tokio::sync::RwLock;
 
 #[tokio::main]
 async fn main() {
     let listener = TcpListener::bind("127.0.0.1:5001").await.unwrap();
 
-    // Static for now but will be dynamic from yaml later....
-    let backend_one = Backend::new(IpAddr::from_str("127.0.0.1").unwrap(), 5002);
-    let backend_two = Backend::new(IpAddr::from_str("127.0.0.1").unwrap(), 5003);
-    let backend_three = Backend::new(IpAddr::from_str("127.0.0.1").unwrap(), 5004);
+    // Static for now but will be dynamic from yaml later there will be a module that can generate
+    // backends
+    let backend_one = Arc::new(RwLock::new(Backend::new(
+        IpAddr::from_str("127.0.0.1").unwrap(),
+        5002,
+    )));
+    let backend_two = Arc::new(RwLock::new(Backend::new(
+        IpAddr::from_str("127.0.0.1").unwrap(),
+        5003,
+    )));
+    let backend_three = Arc::new(RwLock::new(Backend::new(
+        IpAddr::from_str("127.0.0.1").unwrap(),
+        5004,
+    )));
 
     let backends = vec![backend_one, backend_two, backend_three];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,150 +1,23 @@
-use std::{net::IpAddr, str::FromStr};
+use std::net::IpAddr;
+use std::str::FromStr;
 
-use hyper::{
-    body::{Buf, Bytes},
-    {Method, Request, Response, StatusCode, Uri},
-};
-use hyper_util::rt::TokioIo;
+use prism_lb::Backend;
+use prism_lb::Server;
 
-use tokio::{
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
-    net::{TcpListener, TcpStream},
-};
-
-use http_body_util::{BodyExt, Empty, Full};
-
-#[derive(Debug)]
-struct ForwardMessage {
-    method: Method,
-    path: String,
-    host: IpAddr,
-    port: u32,
-}
-
-// TODO: In the future it is a good idea to to a from implementation
-// but we dont even know if this is the correct choice yet so lets leave
-// for now.
-async fn produce_message_from_stream(stream: &mut TcpStream) -> ForwardMessage {
-    let mut buf_reader = BufReader::new(stream).lines();
-    let request_line = buf_reader.next_line().await.unwrap().unwrap();
-
-    let request: Vec<&str> = request_line.split(" ").collect();
-
-    let method = Method::from_str(request[0]).expect("could not parse string to method"); // TODO:
-                                                                                          // handle error
-    let path = request[1].to_string();
-
-    // for now there is no dyanmic back ends for the LB so just hard code to validate
-    let host = IpAddr::from_str("127.0.0.1").expect("wrong host"); // TODO: handle error
-    let port = 5002;
-
-    ForwardMessage {
-        method,
-        path,
-        host,
-        port,
-    }
-}
-
-async fn build_uri_from_message(message: ForwardMessage) -> Uri {
-    let url = Uri::builder()
-        .scheme("http")
-        .authority(format!(
-            "{}:{}",
-            message.host.to_string(),
-            message.port.to_string()
-        ))
-        .path_and_query(message.path)
-        .build()
-        .unwrap(); // TODO: handle error
-
-    url
-}
-
-async fn call_downstream_server(
-    uri: Uri,
-) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-    let host = uri.host().expect("uri has no host");
-    let port = uri.port_u16().unwrap_or(5002);
-
-    let address = format!("{}:{}", host, port);
-
-    let stream = TcpStream::connect(address).await?;
-
-    let io = TokioIo::new(stream);
-
-    let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
-
-    tokio::task::spawn(async move {
-        if let Err(err) = conn.await {
-            println!("Connection failed: {:?}", err);
-        }
-    });
-
-    let authority = uri.authority().unwrap().clone();
-
-    let req = Request::builder()
-        .uri(uri)
-        .header(hyper::header::HOST, authority.as_str())
-        .body(Empty::<Bytes>::new())?;
-
-    let mut res = sender.send_request(req).await?;
-
-    let mut response_bytes: Vec<u8> = Vec::new();
-
-    while let Some(next) = res.frame().await {
-        let frame = next?;
-        if let Some(chunk) = frame.data_ref() {
-            chunk.chunk().iter().for_each(|item| {
-                response_bytes.push(*item);
-            });
-        }
-    }
-
-    Ok(response_bytes)
-}
-
-async fn respond_to_client(bytes: Vec<u8>, mut stream: TcpStream) {
-    let response = Response::builder()
-        .version(hyper::Version::HTTP_11)
-        .status(StatusCode::OK)
-        .header("Content-Type", "text/plain")
-        .header("Content-Length", bytes.len())
-        .body(Full::new(Bytes::from(bytes.clone())))
-        .unwrap();
-
-    let headers = format!(
-        "HTTP/1.1 {}\r\n{:?}\r\n\r\n",
-        response.status(),
-        response.headers()
-    );
-
-    stream.write_all(headers.as_bytes()).await.unwrap();
-    stream
-        .write_all(&response.collect().await.unwrap().to_bytes())
-        .await
-        .unwrap();
-}
-
-async fn process_stream(mut stream: TcpStream) {
-    let message = produce_message_from_stream(&mut stream).await;
-
-    println!("{:?}", message);
-
-    let uri = build_uri_from_message(message).await;
-
-    let downstream_response_bytes = call_downstream_server(uri).await.unwrap();
-
-    respond_to_client(downstream_response_bytes, stream).await;
-}
+use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() {
     let listener = TcpListener::bind("127.0.0.1:5001").await.unwrap();
-    loop {
-        let (stream, _) = listener.accept().await.unwrap();
-        tokio::spawn(async move {
-            process_stream(stream).await;
-        });
-    }
+
+    // Static for now but will be dynamic from yaml later....
+    let backend_one = Backend::new(IpAddr::from_str("127.0.0.1").unwrap(), 5002);
+    let backend_two = Backend::new(IpAddr::from_str("127.0.0.1").unwrap(), 5003);
+    let backend_three = Backend::new(IpAddr::from_str("127.0.0.1").unwrap(), 5004);
+
+    let backends = vec![backend_one, backend_two, backend_three];
+
+    let mut server = Server::new(listener, backends).await;
+
+    server.serve().await;
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,4 @@
+
+
+struct Server {
+    listener: 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,0 @@
-
-
-struct Server {
-    listener: 


### PR DESCRIPTION
This PR aimts to move some of the logic arround instantiating and running a server out of main. We also want to start modeling what a server and backends are. Finnaly adding basic round robin forwarding to a collection of backends. 

_Note to future self a server should have a algorithm field that should be a `algorithm` trait with methods like `next_server()` this will allow us to hide the implementation of the algorithm from the calling code._ 