### PR TITLE
chore: some basic error handeling on process_stream

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,16 @@ async fn main() {
 
     let backends = vec![backend_one, backend_two, backend_three];
 
+    println!("starting lb...");
+    println!("backends: {:?}", backends);
+    println!("port: 5001");
+
+    // TODO: make the algo configurable
+    println!("algorithm: round robin");
+
     let mut server = Server::new(listener, backends).await;
 
-    server.serve().await;
+    if let Err(error) = server.serve().await {
+        println!("{error}");
+    };
 }


### PR DESCRIPTION
This PR aims to add more robust error handling on the current processing of streams. There was lots of `unwarp()` not desirable as if we are not on the happy path a thread will panic. The goal with this PR is to bubble errors up to `process_stream()` log the issue and safley close the thread. 

_Note: There may be situations in the future where we can recover from some errors such as establishing a TCP connection to a downstream server, there is room here to define a timeout for a backend or some of backoff due to unstable network conditions. The problem then becomes how many times do you try or how long can you wait? Let the operator deal with this in what will eventually be their config._ 