### PR TITLE
feat: add unit tests and initial int test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,8 @@ derive-getters = "0.5.0"
 anyhow = "1.0"
 derive-new = "0.7.0"
 env_logger = "0.11.8"
+futures-util = "0.3.31"
 
+[dev-dependencies]
+bollard = "0.19.2"
+reqwest = "0.12.23"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -32,7 +32,7 @@ pub struct BackendConfig {
 impl Backend {
     pub fn new(config: BackendConfig) -> Self {
         Self {
-            config: config,
+            config,
             health_failures: AtomicUsize::new(0),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, net::IpAddr};
 
 use derive_getters::Getters;
-use serde_derive::{Deserialize, Serialize};
+use serde_derive::Deserialize;
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Getters)]
+#[derive(Debug, Deserialize, Getters)]
 #[serde(rename_all = "camelCase")]
 pub struct Config {
     bind_interface: IpAddr,
@@ -12,7 +12,7 @@ pub struct Config {
     pub health_check: HealthCheck,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Getters)]
+#[derive(Debug, Deserialize, Getters)]
 #[serde(rename_all = "camelCase")]
 pub struct HealthCheck {
     pub interval: u64,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use tokio::{fs::File, io::AsyncReadExt};
+
+use bollard::{
+    secret::{ContainerCreateBody, HostConfig, PortBinding},
+    Docker,
+};
+use futures_util::stream::TryStreamExt;
+use std::collections::HashMap;
+
+use prism_lb::{config::Config, server::Server};
+
+const NGINX_IMAGE: &str = "nginx:latest";
+
+pub async fn run_test_containers() {
+    let docker = Docker::connect_with_socket_defaults().unwrap();
+
+    let nginx_one = build_container_config("5001".to_string());
+    let nginx_two = build_container_config("5002".to_string());
+    let nginx_three = build_container_config("5003".to_string());
+
+    let test_containers = vec![nginx_one, nginx_two, nginx_three];
+
+    let _ = &docker
+        .create_image(
+            Some(
+                bollard::query_parameters::CreateImageOptionsBuilder::default()
+                    .from_image(NGINX_IMAGE)
+                    .build(),
+            ),
+            None,
+            None,
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    for (i, v) in test_containers.iter().enumerate() {
+        let container_name = format!("nginx-{}", i);
+
+        let _ = &docker
+            .create_container(
+                Some(
+                    bollard::query_parameters::CreateContainerOptionsBuilder::default()
+                        .name(&container_name)
+                        .build(),
+                ),
+                v.clone(),
+            )
+            .await
+            .unwrap();
+
+        let _ = &docker
+            .start_container(
+                &container_name,
+                None::<bollard::query_parameters::StartContainerOptions>,
+            )
+            .await
+            .unwrap();
+    }
+}
+
+fn build_container_config(host_port: String) -> ContainerCreateBody {
+    let mut nginx_bindings = HashMap::<String, Option<Vec<PortBinding>>>::new();
+    nginx_bindings.insert(
+        String::from("80/tcp"),
+        Some(vec![PortBinding {
+            host_ip: Some(String::from("127.0.0.1")),
+            host_port: Some(String::from(host_port)),
+        }]),
+    );
+
+    ContainerCreateBody {
+        image: Some(NGINX_IMAGE.to_string()),
+        host_config: Some(HostConfig {
+            port_bindings: Some(nginx_bindings),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+async fn build_test_server_config() -> Config {
+    let mut file = File::open("./tests/fixtures/test.yaml").await.unwrap();
+
+    let mut contents = String::new();
+
+    file.read_to_string(&mut contents).await.unwrap();
+
+    Config::try_from(contents).unwrap()
+}
+
+pub async fn test_server() -> Arc<Server> {
+    let config = build_test_server_config().await;
+
+    Arc::new(Server::new(config).await.unwrap())
+}

--- a/tests/fixtures/test.yaml
+++ b/tests/fixtures/test.yaml
@@ -1,0 +1,13 @@
+---
+bindInterface: "0.0.0.0"
+bindPort: 0
+backends:
+  - host: "127.0.0.1"
+    port: 5002
+    healthPath: "/"
+  - host: "127.0.0.1"
+    port: 5003
+    healthPath: "/"
+healthCheck:
+  interval: 60
+  failureThreshold: 3

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,34 @@
+mod common;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use common::{run_test_containers, test_server};
+use http::StatusCode;
+
+#[tokio::test]
+async fn test_backends() {
+    run_test_containers().await;
+    let server = test_server().await;
+    let server_clone = server.clone();
+    let port = server.listener().local_addr().unwrap().port();
+    let address = server.listener().local_addr().unwrap().ip();
+
+    tokio::spawn(async move { server.serve().await.unwrap() });
+
+    for i in 0..3 {
+        let actual = server_clone.count().load(Ordering::SeqCst);
+        let atomic = AtomicUsize::new(i);
+
+        let exepected = atomic.load(Ordering::SeqCst);
+
+        assert_eq!(actual, exepected);
+
+        let result = reqwest::get(format!("http://{}:{}", address, port))
+            .await
+            .unwrap();
+
+        assert_eq!(result.status(), StatusCode::OK);
+
+        assert_eq!(actual, exepected);
+    }
+}


### PR DESCRIPTION
Progresses - https://github.com/logan-bobo/prism-lb/issues/9

- unit tests for backends.
- int tests for initial calling of 3 backends and ensure round robin is working. 