### PR TITLE
feat: add server cleanup fonctionality

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,4 @@
-use crate::backend::{self, Backend, BackendConfig};
+use crate::backend::{Backend, BackendConfig};
 use crate::config::{Config, HealthCheck};
 
 use std::{
@@ -152,7 +152,9 @@ impl Server {
 
         let index = current_count % backend_read.len();
         let backend = backend_read.get(index).unwrap();
-        self.count().fetch_add(1, Ordering::SeqCst);
+        
+        
+        self.count.fetch_add(1, Ordering::SeqCst);
         backend.clone()
     }
 

--- a/tests/fixtures/test.yaml
+++ b/tests/fixtures/test.yaml
@@ -3,6 +3,9 @@ bindInterface: "0.0.0.0"
 bindPort: 0
 backends:
   - host: "127.0.0.1"
+    port: 5001
+    healthPath: "/"
+  - host: "127.0.0.1"
     port: 5002
     healthPath: "/"
   - host: "127.0.0.1"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,8 +6,8 @@ use common::{run_test_containers, test_server};
 use http::StatusCode;
 
 #[tokio::test]
-async fn test_backends() {
-    run_test_containers().await;
+async fn test_backend_routing() {
+    let _containers = run_test_containers().await;
     let server = test_server().await;
     let server_clone = server.clone();
     let port = server.listener().local_addr().unwrap().port();
@@ -28,6 +28,8 @@ async fn test_backends() {
             .unwrap();
 
         assert_eq!(result.status(), StatusCode::OK);
+
+        assert!(result.text().await.unwrap().contains(&i.to_string()));
 
         assert_eq!(actual, exepected);
     }


### PR DESCRIPTION
progresses - https://github.com/logan-bobo/prism-lb/issues/9

Adds a proper drop to nginx containers when the integrations test have ran.